### PR TITLE
[MRG] output total number searched at end

### DIFF
--- a/searcher/src/main.rs
+++ b/searcher/src/main.rs
@@ -157,6 +157,8 @@ fn search<P: AsRef<Path>>(
         error!("Unable to join internal thread: {:?}", e);
     }
 
+    let i: usize = processed_sigs.fetch_max(0, Ordering::SeqCst);
+    info!("DONE. Processed {} search sigs", i);
     Ok(())
 }
 


### PR DESCRIPTION
add logging print at end.

new output:
```
[2022-10-01T13:55:25Z INFO  searcher] Loading queries
[2022-10-01T13:55:25Z INFO  searcher] Loaded 1 query signatures
[2022-10-01T13:55:25Z INFO  searcher] Loading siglist
[2022-10-01T13:55:25Z INFO  searcher] Loaded 3 sig paths in siglist
[2022-10-01T13:55:25Z INFO  searcher] Processed 0 search sigs
[2022-10-01T13:55:25Z INFO  searcher] DONE. Processed 3 search sigs
```

Fixes https://github.com/sourmash-bio/sra_search/issues/7