### PR TITLE
[MRG] ignore empty lines in query or search catalogs

### DIFF
--- a/searcher/src/main.rs
+++ b/searcher/src/main.rs
@@ -112,10 +112,15 @@ fn search<P: AsRef<Path>>(
 
     let queries: Vec<(String, KmerMinHash)> = querylist_file
         .lines()
-        .map(|line| {
-            let mut path = PathBuf::new();
-            path.push(line.unwrap());
-            path
+        .filter_map(|line| {
+            let line = line.unwrap();
+            if line.len() > 0 { // skip empty lines
+                let mut path = PathBuf::new();
+                path.push(line);
+                Some(path)
+            } else {
+                None
+            }
         })
         .filter_map(|query| {
             let query_sig = Signature::from_path(query).unwrap();
@@ -141,10 +146,15 @@ fn search<P: AsRef<Path>>(
     let siglist_file = BufReader::new(File::open(siglist)?);
     let search_sigs: Vec<PathBuf> = siglist_file
         .lines()
-        .map(|line| {
-            let mut path = PathBuf::new();
-            path.push(line.unwrap());
-            path
+        .filter_map(|line| {
+            let line = line.unwrap();
+            if line.len() > 0 {
+                let mut path = PathBuf::new();
+                path.push(line);
+                Some(path)
+            } else {
+                None
+            }
         })
         .collect();
     info!("Loaded {} sig paths in siglist", search_sigs.len());

--- a/searcher/tests/searcher_cmd.rs
+++ b/searcher/tests/searcher_cmd.rs
@@ -83,3 +83,57 @@ fn search_empty_query() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+
+#[test]
+fn search_catalog_empty_line() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("searcher")?;
+
+    let mut queries = NamedTempFile::new()?;
+    writeln!(queries, "tests/data/genome-s10.fa.gz.sig")?;
+
+    let mut catalog = NamedTempFile::new()?;
+    writeln!(catalog, "tests/data/genome-s10.fa.gz.sig")?;
+    writeln!(catalog, "")?;
+
+    cmd.args(&["--threshold", "0"])
+        .args(&["-k", "31"])
+        .args(&["--scaled", "10000"])
+        .arg(queries.path())
+        .arg(catalog.path())
+        .assert()
+        .success()
+        .stdout(contains("query,Run,containment"))
+        .stdout(contains(
+            "../genome-s10.fa.gz','tests/data/genome-s10.fa.gz.sig',1",
+        ));
+
+    Ok(())
+}
+
+#[test]
+fn search_queries_empty_line() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("searcher")?;
+
+    let mut queries = NamedTempFile::new()?;
+    writeln!(queries, "tests/data/genome-s10.fa.gz.sig")?;
+    writeln!(queries, "")?;
+
+    let mut catalog = NamedTempFile::new()?;
+    writeln!(catalog, "tests/data/genome-s10.fa.gz.sig")?;
+
+    cmd.args(&["--threshold", "0"])
+        .args(&["-k", "31"])
+        .args(&["--scaled", "10000"])
+        .arg(queries.path())
+        .arg(catalog.path())
+        .assert()
+        .success()
+        .stdout(contains("query,Run,containment"))
+        .stdout(contains(
+            "../genome-s10.fa.gz','tests/data/genome-s10.fa.gz.sig',1",
+        ));
+
+    Ok(())
+}
+


### PR DESCRIPTION
Note: PR into https://github.com/sourmash-bio/sra_search/pull/14

Ignore lines of length 0 in catalogs.

We could easily use `.trim` to remove leading and trailing whitespace, too. Should we?

Fixes https://github.com/sourmash-bio/sra_search/issues/5
