### PR TITLE
exit from loading loop on first matching sig

### DIFF
--- a/searcher/src/main.rs
+++ b/searcher/src/main.rs
@@ -129,7 +129,7 @@ fn search<P: AsRef<Path>>(
             let mut query = None;
             for sig in &query_sig {
                 if let Some(mh) = prepare_query(sig, &template) {
-                    query = Some((sig.name(), mh.clone()));
+                    query = Some((sig.name(), mh));
                     break;
                 }
             }

--- a/searcher/src/main.rs
+++ b/searcher/src/main.rs
@@ -130,6 +130,7 @@ fn search<P: AsRef<Path>>(
             for sig in &query_sig {
                 if let Some(mh) = prepare_query(sig, &template) {
                     query = Some((sig.name(), mh.clone()));
+                    break;
                 }
             }
             query


### PR DESCRIPTION
Exit when first query sig matching template parameters is found.

This shouldn't matter in terms of results, since .sig files should contain only one compatible signature. But it might improve performance, albeit very marginally 😆 